### PR TITLE
feat(planner): add path planner base class

### DIFF
--- a/neonfc_ssl/control_layer/path_planning/__init__.py
+++ b/neonfc_ssl/control_layer/path_planning/__init__.py
@@ -1,0 +1,1 @@
+from .base_planner import BasePathPlanner

--- a/neonfc_ssl/control_layer/path_planning/base_planner.py
+++ b/neonfc_ssl/control_layer/path_planning/base_planner.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Optional, Union
+import numpy as np
+
+
+class BasePathPlanner(ABC):
+    def __init__(self):
+        self.start = None
+        self.goal = None
+        self.obstacles = []
+        self.map_area = None
+        self.path = None
+
+    @abstractmethod
+    def set_start(self, start: Tuple[float, float]):
+        """Set the start position"""
+        pass
+
+    @abstractmethod
+    def set_goal(self, goal: Tuple[float, float]):
+        """Set the goal position"""
+        pass
+
+    @abstractmethod
+    def set_obstacles(self, obstacles: List):
+        """Set the obstacles in the environment"""
+        pass
+
+    @abstractmethod
+    def set_map_area(self, map_area: Tuple[float, float]):
+        """Set the map boundaries"""
+        pass
+
+    @abstractmethod
+    def plan(self, *args, **kwargs) -> Union[List[Tuple[float, float]], np.ndarray]:
+        """Generate a path from start to goal"""
+        pass
+
+    @abstractmethod
+    def update(self, current_state, *args, **kwargs):
+        """Update the planner with new information (for reactive planners)"""
+        pass
+
+    def get_path(self) -> Optional[Union[List[Tuple[float, float]], np.ndarray]]:
+        """Return the computed path"""
+        return self.path
+
+    def clear(self):
+        """Reset the planner state"""
+        self.start = None
+        self.goal = None
+        self.obstacles = []
+        self.map_area = None
+        self.path = None


### PR DESCRIPTION
# Description

This PR introduces a new abstract base class for path planning algorithms, providing a unified interface for different planning approaches. The base class standardizes method signatures and return types, making it easier to switch between different planning algorithms while maintaining consistent behavior.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran and passed all integration tests
- [ ] Ran and passes all linters
- [ ] Manually tested on simulator
- [ ] Manually tested on physical robots

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

